### PR TITLE
Adiciona teste de acesso a pagina de agentes

### DIFF
--- a/cypress/e2e/agentesPage/compact.cy.js
+++ b/cypress/e2e/agentesPage/compact.cy.js
@@ -1,0 +1,23 @@
+describe("Homepage compactada", () => {
+  beforeEach(() => {
+    cy.viewport(1000, 768);
+    cy.visit("/");
+  });
+  it("acessa \"Agentes\" no navbar", () => {
+    cy.get(".mc-header-menu__btn-mobile").click();
+    cy.contains(".mc-header-menu__itens a", "Agentes").click();
+    cy.url().should("include", "agentes");
+  });
+});
+describe("Pagina de Agentes", () => {
+  beforeEach(() => {
+    cy.viewport(1000, 768);
+    cy.visit("/agentes");
+  });
+
+  it("clica em \"Acessar\" e entra na pagina no agente selecionado", () => {
+    cy.get(":nth-child(2) > .entity-card__footer > .entity-card__footer--action > .button").click();
+    cy.url().should("include", "/agente/118/#info");
+    cy.contains("Junin Oliveira");
+  });
+});

--- a/cypress/e2e/agentesPage/full.cy.js
+++ b/cypress/e2e/agentesPage/full.cy.js
@@ -1,0 +1,23 @@
+describe("HomePage", () => {
+  beforeEach(() => {
+    cy.viewport(1920, 1080);
+    cy.visit("/");
+  });
+
+  it("acessa \"Agentes\" no navbar", () => {
+    cy.contains("a", "Agentes").click();
+    cy.url().should("include", "/agentes");
+  });
+});
+describe("Pagina de Agentes", () => {
+  beforeEach(() => {
+    cy.viewport(1920, 1080);
+    cy.visit("/agentes");
+  });
+
+  it("clica em \"Acessar\" e entra na pagina no agente selecionado", () => {
+    cy.get(":nth-child(2) > .entity-card__footer > .entity-card__footer--action > .button").click();
+    cy.url().should("include", "/agente/118/#info");
+    cy.contains("Junin Oliveira");
+  });
+});


### PR DESCRIPTION
Garante que o usuário consiga: 
-  Clicar na página "Agentes" e que carregue os artistas cadastrados.
- Clicar em "Acessar" na parte inferior das informações prévias do agente.
- Após o click em "Acessar" direcione para a página contendo as informações referente ao agente escolhido.