### PR TITLE
Adiciona teste de acesso a pagina de espaços

### DIFF
--- a/cypress/e2e/spacesPage/compact.cy.js
+++ b/cypress/e2e/spacesPage/compact.cy.js
@@ -1,0 +1,25 @@
+describe("Homepage compactada", () => {
+  beforeEach(() => {
+    cy.viewport(1000, 768);
+    cy.visit("/");
+  });
+
+  it("acessa \"Espaços\" no navbar", () => {
+    cy.get(".mc-header-menu__btn-mobile").click();
+    cy.contains(".mc-header-menu__itens a", "Espaços").click();
+    cy.url().should("include", "/espacos/#list");
+  });
+});
+
+describe("Pagina de Espaços", () => {
+  beforeEach(() => {
+    cy.viewport(1000, 768);
+    cy.visit("/espacos/#list");
+  });
+
+  it("clica em \"Acessar\" e entra na pagina no espaço selecionado", () => {
+    cy.get(":nth-child(2) > .entity-card__footer > .entity-card__footer--action > .button").click();
+    cy.url().should("include", "/espaco/34/#info");
+    cy.contains("Henri Hyatt");
+  });
+});

--- a/cypress/e2e/spacesPage/full.cy.js
+++ b/cypress/e2e/spacesPage/full.cy.js
@@ -1,0 +1,24 @@
+describe("HomePage", () => {
+  beforeEach(() => {
+    cy.viewport(1920, 1080);
+    cy.visit("/");
+  });
+
+  it("acessa \"Espaços\" no navbar", () => {
+    cy.contains("a", "Espaços").click();
+    cy.url().should("include", "/espacos/#list");
+  });
+});
+
+describe("Pagina de Espaços", () => {
+  beforeEach(() => {
+    cy.viewport(1920, 1080);
+    cy.visit("/espacos/#list");
+  });
+
+  it("clica em \"Acessar\" e entra na pagina no espaço selecionado", () => {
+    cy.get(":nth-child(2) > .entity-card__footer > .entity-card__footer--action > .button").click();
+    cy.url().should("include", "/espaco/34/#info");
+    cy.contains("Henri Hyatt");
+  });
+});


### PR DESCRIPTION
Garante que o usuário consiga:
- Clicar na página "Espaços" e que carregue os espaços cadastrados.
- Clicar em "Acessar" na parte inferior das informações prévias do espaço.
- Após o click em "Acessar" direcione para a página contendo as informações referente ao espaço escolhido.