### PR TITLE
Adiciona testes de clique para opções da página de 'Dúvidas Frequentes'

### DIFF
--- a/cypress/commands/backFaqPage.js
+++ b/cypress/commands/backFaqPage.js
@@ -1,0 +1,7 @@
+function backFaqPage () {
+  cy.wait(1000);
+  cy.contains("a", "Dúvidas frequentes").click();
+  cy.url().should("include", "perguntas-frequentes/");
+}
+
+module.exports = { backFaqPage };

--- a/cypress/e2e/faqPage/index.cy.js
+++ b/cypress/e2e/faqPage/index.cy.js
@@ -1,0 +1,26 @@
+import { backFaqPage } from "../../commands/backFaqPage";
+
+describe("faqPage", () => {
+  beforeEach(() => {
+    cy.visit("/");
+    cy.contains("a", "Dúvidas frequentes").click();
+  });
+
+  it("Garante que as opções do menu 'Dúvidas Frequentes' sejam clicáveis", () => {
+    const url = [
+      "https://redesign.testes.map.as/perguntas-frequentes/cadastro/",
+      "https://redesign.testes.map.as/perguntas-frequentes/IntroducaoMapa/",
+      "https://redesign.testes.map.as/perguntas-frequentes/inscricao/"
+    ];
+
+    url.forEach(url => {
+      cy.get(`.faq__frequent > [href="${url}"]`).click();
+      backFaqPage();
+    });
+
+    url.forEach(url => {
+      cy.get(`.faq__links > [href="${url}"]`).click();
+      backFaqPage();
+    });
+  });
+});


### PR DESCRIPTION
- Adicionado teste para verificar se as opções na página de "Dúvidas Frequentes" são clicáveis.
- Adicionado comando para retornar à página de "Dúvidas Frequentes" após cada clique em uma opção.